### PR TITLE
Fix BarrierDismissible

### DIFF
--- a/lib/progress_dialog.dart
+++ b/lib/progress_dialog.dart
@@ -125,7 +125,7 @@ class ProgressDialog {
         _dialog = new _Body();
         showDialog<dynamic>(
           context: _context,
-          barrierDismissible: false,
+          barrierDismissible: _barrierDismissible,
           builder: (BuildContext context) {
             _dismissingContext = context;
             return WillPopScope(


### PR DESCRIPTION
When isDismissible is set to true, tapped the barrier should be dismiss dialog
If it using in iOS device, user will can't cancel this task

before
![before](https://user-images.githubusercontent.com/39433862/76394264-271fa280-63b0-11ea-991a-a0bc4b154081.gif)

after
![after](https://user-images.githubusercontent.com/39433862/76394267-2981fc80-63b0-11ea-860b-62182cbde8d1.gif)
