### PR TITLE
Added message text to constructor

### DIFF
--- a/lib/progress_dialog.dart
+++ b/lib/progress_dialog.dart
@@ -39,11 +39,13 @@ class ProgressDialog {
 
   ProgressDialog(BuildContext context,
       {ProgressDialogType type,
+        String message,
         bool isDismissible,
         bool showLogs,
         TextDirection textDirection,
         Widget customBody}) {
     _context = context;
+    _dialogMessage = message ?? _dialogMessage;
     _progressDialogType = type ?? ProgressDialogType.Normal;
     _barrierDismissible = isDismissible ?? true;
     _showLogs = showLogs ?? false;


### PR DESCRIPTION
If I want to make a simple progress dialog with some text, I can't do that without creating, then styling the dialog (two steps that could be one). In this change, 

To fix this, I added the `message` property to the constructor so I can do both in a single call:

```dart
 pr = ProgressDialog(
  context,
  type: ProgressDialogType.Normal, 
  message: 'This is my message',
  isDismissible: false,
);
```

### What's this PR do?

Makes it so you can set the message in the constructor.
